### PR TITLE
Fix tpm*_id failing to find existing NVRAM area

### DIFF
--- a/sbin/tpm2_id
+++ b/sbin/tpm2_id
@@ -29,8 +29,13 @@ getindex() {
 }
 
 getid() {
+    # Do not use `-q` flag of grep.  The flag makes grep exit on finding a match
+    # before reaching EOF.  Closing of grep's input stream can result in
+    # tpm2_nvreadpublic failing to write to its output stream and error, which
+    # then becomes the result of the whole pipe due to the use of
+    # `set -o pipefail` at the top.
     if ! tpm2_nvreadpublic "$TPM_ID_INDEX" 2>/dev/null |
-           grep -iq "writedefine"; then
+           grep -i "writedefine" >/dev/null; then
         log "TPM NVRAM area at index $TPM_ID_INDEX is not defined!"
         log "Hint: did you run 'anti-evil-maid-tpm-setup'?"
         echo "unknown"

--- a/sbin/tpm_id
+++ b/sbin/tpm_id
@@ -29,7 +29,12 @@ getindex() {
 }
 
 getid() {
-    if ! tpm_nvinfo -i "$TPM_ID_INDEX" | grep -q "WRITEDEFINE"; then
+    # Do not use `-q` flag of grep.  The flag makes grep exit on finding a match
+    # before reaching EOF.  Closing of grep's input stream can result in
+    # tpm_nvinfo failing to write to its output stream and error, which then
+    # becomes the result of the whole pipe due to the use of `set -o pipefail`
+    # at the top.
+    if ! tpm_nvinfo -i "$TPM_ID_INDEX" | grep "WRITEDEFINE" >/dev/null; then
         log "TPM NVRAM area at index $TPM_ID_INDEX is not defined!"
         log "Hint: did you run 'anti-evil-maid-tpm-setup'?"
         echo "unknown"


### PR DESCRIPTION
Do not use `-q` flag of grep.  The flag makes grep exit on finding a match before reaching EOF.  Closing of grep's input stream can result in tpm_nvinfo/tpm2_nvreadpublic failing to write to its output stream and error, which then becomes the result of the whole pipe due to the use of `set -o pipefail` at the top.

Observed on Qubes OS 4.2 with TPM2, but updated tpm_id as well just in case it's affected or will be affected in the future.  This wasn't caught before probably because the behaviour has changed either in grep or in tpm2_nvreadpublic.